### PR TITLE
Added functionality for converting cue files to midi

### DIFF
--- a/source/authoring_validation.py
+++ b/source/authoring_validation.py
@@ -69,7 +69,9 @@ class authoringValidator():
     def validate_midi(self):
         '''loads midi and reports if there are duplicates in the same track'''
     
-        if self.midi_file=="" or os.path.splitext(self.midi_file)[1] != ".mid":
+        if self.midi_file=="":
+            return True
+        if os.path.splitext(self.midi_file)[1] != ".mid":
             self.major_error = True
             self.add_error("FILE SPECIFIED FOR MIDI FILE IS NOT VALID:\n {midi_file}".format(midi_file=os.path.basename(self.midi_file)))
             return False

--- a/source/config.py
+++ b/source/config.py
@@ -47,6 +47,7 @@ class config():
     autoSongID = False
     inGameAuthor = False
     ignoreMinorErrors = False
+    convertCuesToMidi = False
     
     def load_config(self):
         f = open(self.configFilename, 'r')
@@ -88,6 +89,7 @@ class config():
         self.autoSongID = desc_file["autoSongID"]
         self.inGameAuthor = desc_file["inGameAuthor"]
         self.ignoreMinorErrors = desc_file["ignoreMinorErrors"]
+        self.convertCuesToMidi = desc_file["convertCuesToMidi"]
         f.close()
         
     def save_config(self):
@@ -128,7 +130,8 @@ class config():
         line = line + "\t\"expert_cues\": " + json.dumps(self.expert_cues) + ",\n"
         line = line + "\t\"autoSongID\": " + json.dumps(self.autoSongID) + ",\n"
         line = line + "\t\"inGameAuthor\": " + json.dumps(self.inGameAuthor) + ",\n"
-        line = line + "\t\"ignoreMinorErrors\": " + json.dumps(self.ignoreMinorErrors) + "\n"
+        line = line + "\t\"ignoreMinorErrors\": " + json.dumps(self.ignoreMinorErrors) + ",\n"
+        line = line + "\t\"convertCuesToMidi\": " + json.dumps(self.convertCuesToMidi) + "\n"
         line = line + "}"
         
         f = open(self.configFilename, "w")

--- a/source/error_checker.py
+++ b/source/error_checker.py
@@ -122,7 +122,22 @@ class errorChecker():
         midi = self.midi
         cues = [self.beginner_cues, self.moderate_cues, self.advanced_cues, self.expert_cues]
         checks = []
-        if self.useMidiForCues == False:
+        
+        if self.cuesToMidi == True:
+            for file in cues:
+                if os.path.isfile(file):
+                    if file[-5:] == ".cues":
+                        checks.append(True)
+                    else:
+                        checks.append(False)
+                else:
+                    checks.append(False)
+            if self.cuesToMidi == True:
+                if not any(checks):
+                    self.majorErrors.append("No cues file to convert/ invalid file, need at least one.")
+                    self.majorErrors.append("If you didn't mean to convert cue to midi, uncheck it")
+        
+        elif self.useMidiForCues == False:
             if os.path.isfile(midi) == False:
                 self.minorErrors.append("MIDI file does not exist.")
             else:
@@ -136,8 +151,9 @@ class errorChecker():
                         checks.append(False)
                 else:
                     checks.append(False)
+
             if checks[0] == False and checks[1] == False and checks[2] == False and checks[3] == False:
-                self.majorErrors.append("No cues file exists, need at least one.")
+                self.majorErrors.append("No cues file exists/ invalid file, need at least one.")
                 self.majorErrors.append("If you are using MIDI for cues you must tick the checkbox.")
             else:
                 if checks[0] == False:
@@ -179,7 +195,6 @@ class errorChecker():
         try:
             pattern = midi.read_midifile(midifile)
             ppq = pattern.resolution
-            self.midi_tempo = 0
             for track in pattern:
                 for event in track:
                     if type(event) is midi.SetTempoEvent:
@@ -189,11 +204,7 @@ class errorChecker():
                             else:
                                 self.majorErrors.append("PPQ of MIDI file is not 480.")
                         else:
-                            if self.midi_tempo != 0:
-                                if self.midi_tempo != event.get_bpm():
-                                    self.majorErrors.append("Audica only supports one BPM marker")
-                            else:
-                                self.majorErrors.append("Error getting BPM.")
+                            self.majorErrors.append("Error getting BPM.")
         except:
             self.majorErrors.append("Error loading MIDI file.")
     
@@ -280,7 +291,7 @@ class errorChecker():
                 self.sustain_r_channels = oggInfo[1]
                 self.sustain_r_bitrate = oggInfo[2]
                 self.sustain_r_sample_rate = oggInfo[3]
-                self.audio_to_convert.append(["_sustain_r", self.sustain_r_audio])
+                self.audio_to_convert.append("_sustain_r", self.sustain_r_audio)
                 if self.sustain_r_channels != 1:
                     self.minorErrors.append("Right sustain audio does not have 1 channel.")
             except:
@@ -296,6 +307,3 @@ class errorChecker():
         bitrate = f.info.bitrate
         sample_rate = f.info.sample_rate
         return [length, channels, bitrate, sample_rate]
-
-#error_checker = errorChecker()
-#print error_checker.ogg_info("ddududduduremix-RIGHT.ogg")


### PR DESCRIPTION
Added checkbox for option to convert from cue files to midi file and functionality.

Wrapped midi_handler cues_to_midi in a class. This was done to allow for multiple cue files (difficulties) to be merged into a single midi file.

Added a few lines to the new class and seperated various parts of the original cues_to_midi function into their own methods.

Added some basic logic to make the class work.

Integrated these into main.make_audica_file near to the other data preparation parts.

Added saving and loading capabilities for cues to midi conversion option.

Adjusted error_checker to allow for someone to specify they want midi for cues, and to check convert cues to midi, even without specifying a midi file as long as they specify at least one cue file.

Lots of other changes in the background to main, config, etc, to fully integrate the new kind of midi_handler.